### PR TITLE
Throttling

### DIFF
--- a/cloudwatch.go
+++ b/cloudwatch.go
@@ -7,6 +7,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
 
+// Throttling and limits from http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html
+const (
+	// The maximum rate of a GetLogEvents request is 10 requests per second per AWS account.
+	readThrottle = time.Second / 10
+
+	// The maximum rate of a PutLogEvents request is 5 requests per second per log stream.
+	writeThrottle = time.Second / 5
+)
+
 // now is a function that returns the current time.Time. It's a variable so that
 // it can be stubbed out in unit tests.
 var now = time.Now

--- a/example/main.go
+++ b/example/main.go
@@ -33,7 +33,7 @@ func main() {
 		var i int
 		for {
 			i++
-			<-time.After(time.Second)
+			<-time.After(time.Second / 30)
 			_, err := fmt.Fprintf(w, "Line %d\n", i)
 			if err != nil {
 				log.Println(err)

--- a/reader.go
+++ b/reader.go
@@ -2,6 +2,8 @@ package cloudwatch
 
 import (
 	"bytes"
+	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -10,34 +12,43 @@ import (
 // Reader is an io.Reader implementation that streams log lines from cloudwatch
 // logs.
 type Reader struct {
-	b bytes.Buffer
-
 	group, stream, nextToken *string
 
 	client client
+
+	throttle <-chan time.Time
+
+	b lockingBuffer
 }
 
 func NewReader(group, stream string, client *cloudwatchlogs.CloudWatchLogs) *Reader {
-	return &Reader{
-		group:  aws.String(group),
-		stream: aws.String(stream),
-		client: client,
+	r := &Reader{
+		group:    aws.String(group),
+		stream:   aws.String(stream),
+		client:   client,
+		throttle: time.Tick(readThrottle),
+	}
+	go r.start()
+	return r
+}
+
+func (r *Reader) start() error {
+	for {
+		<-r.throttle
+		if err := r.read(); err != nil {
+			return err
+		}
 	}
 }
 
-func (r *Reader) Read(b []byte) (int, error) {
-	// Drain existing buffered data.
-	if r.b.Len() > 0 {
-		return r.b.Read(b)
-	}
-
+func (r *Reader) read() error {
 	resp, err := r.client.GetLogEvents(&cloudwatchlogs.GetLogEventsInput{
 		LogGroupName:  r.group,
 		LogStreamName: r.stream,
 		NextToken:     r.nextToken,
 	})
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	// We want to re-use the existing token in the event that
@@ -49,12 +60,42 @@ func (r *Reader) Read(b []byte) (int, error) {
 
 	// If there are no messages, return so that the consumer can read again.
 	if len(resp.Events) == 0 {
-		return 0, nil
+		return nil
 	}
 
 	for _, event := range resp.Events {
 		r.b.WriteString(*event.Message)
 	}
 
+	return nil
+}
+
+func (r *Reader) Read(b []byte) (int, error) {
+	// If there is not data right now, return. Reading from the buffer would
+	// result in io.EOF being returned, which is not what we want.
+	if r.b.Len() == 0 {
+		return 0, nil
+	}
+
 	return r.b.Read(b)
+}
+
+// lockingBuffer is a bytes.Buffer that locks Reads and Writes.
+type lockingBuffer struct {
+	sync.Mutex
+	bytes.Buffer
+}
+
+func (r *lockingBuffer) Read(b []byte) (int, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Buffer.Read(b)
+}
+
+func (r *lockingBuffer) Write(b []byte) (int, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Buffer.Write(b)
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -25,6 +25,9 @@ func TestReader(t *testing.T) {
 		},
 	}, nil)
 
+	err := r.read()
+	assert.NoError(t, err)
+
 	b := make([]byte, 1000)
 	n, err := r.Read(b)
 	assert.NoError(t, err)
@@ -49,6 +52,9 @@ func TestReader_Buffering(t *testing.T) {
 			{Message: aws.String("Hello"), Timestamp: aws.Int64(1000)},
 		},
 	}, nil)
+
+	err := r.read()
+	assert.NoError(t, err)
 
 	b := make([]byte, 3)
 	n, err := r.Read(b) //Hel
@@ -98,14 +104,23 @@ func TestReader_EndOfFile(t *testing.T) {
 		Events: []*cloudwatchlogs.OutputLogEvent{},
 	}, nil)
 
+	err := r.read()
+	assert.NoError(t, err)
+
 	b := make([]byte, 5)
 	n, err := r.Read(b) //Hello
 	assert.NoError(t, err)
 	assert.Equal(t, 5, n)
 
+	err = r.read()
+	assert.NoError(t, err)
+
 	n, err = r.Read(b) //World
 	assert.NoError(t, err)
 	assert.Equal(t, 5, n)
+
+	err = r.read()
+	assert.NoError(t, err)
 
 	// Attempt to read more data, but there is none.
 	n, err = r.Read(b)


### PR DESCRIPTION
This implements throttling according to http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html to prevent rate limiting.
